### PR TITLE
Added owner field and filtering for owners. Added/modified unit tests…

### DIFF
--- a/examples/angularjs/index.html
+++ b/examples/angularjs/index.html
@@ -15,7 +15,13 @@
 				<header id="header">
 					<h1>todos</h1>
 					<form id="todo-form" ng-submit="addTodo()">
-						<input id="new-todo" placeholder="What needs to be done?" ng-model="newTodo" ng-disabled="saving" autofocus>
+							<div id="new-todo">
+								<label for="owner">Owner: </label>
+								<select id="owner" ng-model="newTodoOwner" ng-disabled="saving" autofocus>
+								  <option ng-repeat="owner in owners" ng-value="owner">{{owner}}</option>
+								</select>
+								<input  placeholder="What needs to be done?" ng-model="newTodo" ng-disabled="saving" autofocus>
+							</div>
 					</form>
 				</header>
 				<section id="main" ng-show="todos.length" ng-cloak>
@@ -25,11 +31,17 @@
 						<li ng-repeat="todo in todos | filter:statusFilter track by $index" ng-class="{completed: todo.completed, editing: todo == editedTodo}">
 							<div class="view">
 								<input class="toggle" type="checkbox" ng-model="todo.completed" ng-change="toggleCompleted(todo)">
-								<label ng-dblclick="editTodo(todo)">{{todo.title}}</label>
+								<label ng-dblclick="editTodo(todo)">Owner: {{todo.owner}}</label>
+								<label ng-dblclick="editTodo(todo)"  >{{todo.title}}</label>
 								<button class="destroy" ng-click="removeTodo(todo)"></button>
 							</div>
 							<form ng-submit="saveEdits(todo, 'submit')">
-								<input class="edit" ng-trim="false" ng-model="todo.title" todo-escape="revertEdits(todo)" ng-blur="saveEdits(todo, 'blur')" todo-focus="todo == editedTodo">
+								<div ng-blur="saveEdits(todo, 'blur')" todo-escape="revertEdits(todo)" >
+									<select id="ownerSelect" class="edit" label="Owner:	" ng-model="todo.owner" todo-escape="revertEdits(todo)">
+									  <option ng-repeat="owner in owners" ng-value="owner">{{owner}}</option>
+									</select>
+									<input class="edit" ng-trim="false" ng-model="todo.title" todo-focus="todo == editedTodo">
+								</div>
 							</form>
 						</li>
 					</ul>
@@ -38,18 +50,23 @@
 					<span id="todo-count"><strong>{{remainingCount}}</strong>
 						<ng-pluralize count="remainingCount" when="{ one: 'item left', other: 'items left' }"></ng-pluralize>
 					</span>
-					<ul id="filters">
-						<li>
-							<a ng-class="{selected: status == ''} " href="#/">All</a>
-						</li>
-						<li>
-							<a ng-class="{selected: status == 'active'}" href="#/active">Active</a>
-						</li>
-						<li>
-							<a ng-class="{selected: status == 'completed'}" href="#/completed">Completed</a>
-						</li>
-					</ul>
-					<button id="clear-completed" ng-click="clearCompletedTodos()" ng-show="completedCount">Clear completed</button>
+						<ul id="filters">
+							<li>
+								<a ng-class="{selected: status == 'all'} " href="#/all">All</a>
+							</li>
+							<li>
+								<a ng-class="{selected: status == 'active'}" href="#/active">Active</a>
+							</li>
+							<li>
+								<a ng-class="{selected: status == 'completed'}" href="#/completed">Completed</a>
+							</li>
+						</ul>
+						<button id="clear-completed" ng-click="clearCompletedTodos()" ng-show="completedCount">Clear completed</button>
+						<ul id="ownerFilters">
+							<li ng-repeat="owner in owners">
+								<a ng-class="{selected: ownedBy == owner} " href="#/{{status}}/{{owner}}">{{owner}}</a>
+							</li>
+						</ul>
 				</footer>
 			</section>
 			<footer id="info">

--- a/examples/angularjs/js/app.js
+++ b/examples/angularjs/js/app.js
@@ -24,9 +24,8 @@ angular.module('todomvc', ['ngRoute', 'ngResource'])
 		};
 
 		$routeProvider
-			.when('/', routeConfig)
-			.when('/:status', routeConfig)
+			.when('/:status/:owner?', routeConfig)
 			.otherwise({
-				redirectTo: '/'
+				redirectTo: '/all'
 			});
 	});

--- a/examples/angularjs/js/controllers/todoCtrl.js
+++ b/examples/angularjs/js/controllers/todoCtrl.js
@@ -12,29 +12,39 @@ angular.module('todomvc')
 		var todos = $scope.todos = store.todos;
 
 		$scope.newTodo = '';
+		$scope.newTodoOwner = '';
+		$scope.owners = store.availableOwners;
 		$scope.editedTodo = null;
 
 		$scope.$watch('todos', function () {
-			$scope.remainingCount = $filter('filter')(todos, { completed: false }).length;
-			$scope.completedCount = todos.length - $scope.remainingCount;
+			var filter = { completed: true };
+			$scope.completedCount = $filter('filter')(todos, filter).length;
+			$scope.remainingCount = todos.length - $scope.completedCount;
 			$scope.allChecked = !$scope.remainingCount;
 		}, true);
 
 		// Monitor the current route for changes and adjust the filter accordingly.
 		$scope.$on('$routeChangeSuccess', function () {
 			var status = $scope.status = $routeParams.status || '';
+			var ownedBy = $scope.ownedBy = $routeParams.owner || '';
 			$scope.statusFilter = (status === 'active') ?
 				{ completed: false } : (status === 'completed') ?
 				{ completed: true } : {};
+			if(ownedBy){
+				$scope.statusFilter['owner'] = ownedBy;
+			}
+			console.log('status', $routeParams.status);
+			console.log('owner', $routeParams.owner);
 		});
 
 		$scope.addTodo = function () {
 			var newTodo = {
 				title: $scope.newTodo.trim(),
+				owner: $scope.newTodoOwner,
 				completed: false
 			};
 
-			if (!newTodo.title) {
+			if (!newTodo.title || !newTodo.owner) {
 				return;
 			}
 
@@ -42,6 +52,7 @@ angular.module('todomvc')
 			store.insert(newTodo)
 				.then(function success() {
 					$scope.newTodo = '';
+					$scope.newTodoOwner = '';
 				})
 				.finally(function () {
 					$scope.saving = false;
@@ -72,7 +83,7 @@ angular.module('todomvc')
 
 			todo.title = todo.title.trim();
 
-			if (todo.title === $scope.originalTodo.title) {
+			if (todo.title === $scope.originalTodo.title && todo.ownwer === $scope.originalTodo.owner) {
 				$scope.editedTodo = null;
 				return;
 			}
@@ -80,6 +91,7 @@ angular.module('todomvc')
 			store[todo.title ? 'put' : 'delete'](todo)
 				.then(function success() {}, function error() {
 					todo.title = $scope.originalTodo.title;
+					todo.owner = $scope.originalTodo.owner;
 				})
 				.finally(function () {
 					$scope.editedTodo = null;

--- a/examples/angularjs/js/services/todoStorage.js
+++ b/examples/angularjs/js/services/todoStorage.js
@@ -27,6 +27,8 @@ angular.module('todomvc')
 		var store = {
 			todos: [],
 
+			availableOwners: ['Tom','Dick','Harry'],
+
 			api: $resource('/api/todos/:id', null,
 				{
 					update: { method:'PUT' }
@@ -94,6 +96,8 @@ angular.module('todomvc')
 
 		var store = {
 			todos: [],
+
+			availableOwners: ['Tom','Dick','Harry'],
 
 			_getFromLocalStorage: function () {
 				return JSON.parse(localStorage.getItem(STORAGE_ID) || '[]');

--- a/examples/angularjs/node_modules/todomvc-app-css/index.css
+++ b/examples/angularjs/node_modules/todomvc-app-css/index.css
@@ -197,8 +197,8 @@ label[for='toggle-all'] {
 }
 
 #todo-list li label {
-	white-space: pre-line;
-	word-break: break-all;
+	white-space: pre;
+	word-break: break-word;
 	padding: 15px 60px 15px 15px;
 	margin-left: 45px;
 	display: block;
@@ -249,7 +249,7 @@ label[for='toggle-all'] {
 #footer {
 	color: #777;
 	padding: 10px 15px;
-	height: 20px;
+	height: 40px;
 	text-align: center;
 	border-top: 1px solid #e6e6e6;
 }
@@ -306,6 +306,37 @@ label[for='toggle-all'] {
 }
 
 #filters li a.selected {
+	border-color: rgba(175, 47, 47, 0.2);
+}
+
+#ownerFilters {
+	margin:25px;
+	padding: 0;
+	list-style: none;
+	position: absolute;
+	right: 0;
+	left: 0;
+}
+
+#ownerFilters li {
+	display: inline;
+}
+
+#ownerFilters li a {
+	color: inherit;
+	margin: 3px;
+	padding: 3px 7px;
+	text-decoration: none;
+	border: 1px solid transparent;
+	border-radius: 3px;
+}
+
+#ownerFilters li a.selected,
+#ownerFilters li a:hover {
+	border-color: rgba(175, 47, 47, 0.1);
+}
+
+#ownerFilters li a.selected {
 	border-color: rgba(175, 47, 47, 0.2);
 }
 
@@ -373,6 +404,10 @@ html #clear-completed:active {
 	}
 
 	#filters {
+		bottom: 10px;
+	}
+
+	#ownerFilters {
 		bottom: 10px;
 	}
 }


### PR DESCRIPTION
The app is upgraded to include a owner drop down which associates owner information to the todo title. The owner is shown above the todo title and is labeled as "Owner:".  There are new unit tests for all features added and modified.

There are some behaviors that aren't supported well by the new feature, usability issues, and some styling issues:

- (Usability) The input form used to submit todos by pressing enter. The drop down does not behave the same according to those events, thus the user can press enter in the text box to complete an add or edit, but cannot press enter on the drop down to achieve the same effect. This may warrant the addition of a new button to perform add and edit.

- (Styling) The owner select drop down isn't styled well to fit in the original design, and the styles that were once applied to the todo input box are also currently misapplied. The text size is also a bit large.

- (Maintainability) The ownersAvailable in the service should be set by a .config() instead of hard coded.

Remaining work:

- The todos cannot be entered with just keyboard strokes. The listing of todos must be changed to allow tab stops, either by assigning them explicitly or by adding a button (focusable) to naturally become a tabstop. The button could allow entering edit/remove mode.
